### PR TITLE
handle statuscode 401

### DIFF
--- a/transip_rest_client/transip_rest_client.py
+++ b/transip_rest_client/transip_rest_client.py
@@ -108,7 +108,7 @@ class TransipRestClient(GenericRestClient):
                                                         extra_headers=self._transip_headers())
         self._update_bookkeeping(headers)
 
-        if statuscode not in expected_http_codes:
+        if statuscode not in expected_http_codes or statuscode == 401:
             if statuscode == 401:
                 errormsg = json.loads(jsonstr)['error']
                 raise TransIPRestResponseException(statuscode=statuscode, errormsg=errormsg)


### PR DESCRIPTION
A few lines above this line 401 is added to `expected_http_codes`, I'm not sure why but if statuscode is 401 it will never execute the block below the changed line in this PR. Add this as a workaround to get sane error messages in case of a 401.